### PR TITLE
Make the code faster by compiling regex on global context and reusing named collection.

### DIFF
--- a/giturlparse/parser.py
+++ b/giturlparse/parser.py
@@ -107,7 +107,7 @@ class Parser(object):
     def _get_protocols(self):
         try:
             index = self._url.index('://')
-
-            return self._url[0:index].split('+')
         except ValueError:
             return []
+
+        return self._url[:index].split('+')

--- a/giturlparse/parser.py
+++ b/giturlparse/parser.py
@@ -23,6 +23,18 @@
 import collections
 import re
 
+Parsed = collections.namedtuple('Parsed', [
+    'pathname',
+    'protocols',
+    'protocol',
+    'href',
+    'resource',
+    'user',
+    'port',
+    'name',
+    'owner',
+])
+
 
 class ParserError(Exception):
     """ Error raised when a URL can't be parsed. """
@@ -36,19 +48,6 @@ class Parser(object):
 
     def __init__(self, url):
         self._url = url
-
-    def get_parsed(self):
-        return collections.namedtuple('Parsed', [
-            'pathname',
-            'protocols',
-            'protocol',
-            'href',
-            'resource',
-            'user',
-            'port',
-            'name',
-            'owner',
-        ])
 
     def parse(self):
         """
@@ -102,9 +101,7 @@ class Parser(object):
             msg = "Invalid URL '{}'".format(self._url)
             raise ParserError(msg)
 
-        p = self.get_parsed()
-
-        return p(**d)
+        return Parsed(**d)
 
     def _get_protocols(self):
         try:


### PR DESCRIPTION
Running the following code as benchmark

```python
import timeit
import giturlparse

URLS = [
    'git@github.com:jaysonsantos/abc.git',
    'https://github.com/jaysonsantos/abc.git'
]

print(timeit.timeit(
    """
parsed = [giturlparse.parse(url) for url in URLS]
""",
    number=100_000,
    globals={
        'URLS': URLS,
        'giturlparse': giturlparse
    }))
```

on master it returned `20.684334864999997` and on my branch `1.4601109110000001`